### PR TITLE
devicePixelRatio must be more than 1.1

### DIFF
--- a/src/retina.js
+++ b/src/retina.js
@@ -57,7 +57,7 @@
     Retina.isRetina = function(){
         var mediaQuery = '(-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 3/2), (min-resolution: 1.5dppx)';
 
-        if (root.devicePixelRatio > 1) {
+        if (root.devicePixelRatio > 1.1) {
             return true;
         }
 


### PR DESCRIPTION
Firefox 43.0.1 return window.devicePixelRatio 1.0909091234207153 on the not retina display.
